### PR TITLE
perf: writeToBuffer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,10 @@
     "max-len": [
       "error",
       { "code": 80 }
+    ],
+    "quotes": [
+      "error",
+      "single"
     ]
   },
   "overrides": [

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 # Vim
 *.swp
 
+package-lock.json

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "benchmarks",
+  "version": "1.0.0",
+  "description": "",
+  "main": "writeToBuffer.js",
+  "scripts": {
+    "bench-1": "node writeToBuffer.js",
+    "bench-2":"VERSION=2.0.2 node writeToBuffer.js",
+    "bench":"npm run bench-1 && npm run bench-2"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "mcnbt": "2.0.1",
+    "benchmark": "^2.1.4"
+  }
+}

--- a/benchmarks/writeToBuffer.js
+++ b/benchmarks/writeToBuffer.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+v: 2.0.1 , r: 1b x 66,319 ops/sec ±70.40% (88 runs sampled)
+v: 2.0.1 , r: 1kb x 32,589 ops/sec ±0.96% (90 runs sampled)
+v: 2.0.1 , r: 2kb x 18,932 ops/sec ±0.51% (93 runs sampled)
+v: 2.0.1 , r: 4kb x 10,554 ops/sec ±0.44% (94 runs sampled)
+v: 2.0.1 , r: 8kb x 5,425 ops/sec ±0.56% (91 runs sampled)
+
+v: 2.0.2 , r: 1b x 159,682 ops/sec ±0.49% (92 runs sampled)
+v: 2.0.2 , r: 1kb x 35,753 ops/sec ±0.57% (90 runs sampled)
+v: 2.0.2 , r: 2kb x 19,579 ops/sec ±0.67% (95 runs sampled)
+v: 2.0.2 , r: 4kb x 10,397 ops/sec ±0.48% (95 runs sampled)
+v: 2.0.2 , r: 8kb x 5,168 ops/sec ±0.35% (95 runs sampled)
+*/
+
+let NBT;
+let version;
+
+if (process.env.VERSION === '2.0.2') {
+  NBT = require('../');
+  version = '2.0.2';
+} else {
+  NBT = require('mcnbt');
+  version = '2.0.1';
+}
+
+const Benchmark = require('benchmark');
+
+function test(byteCount = 5) {
+  const short = new NBT.Tags.TAGShort();
+  short.setValue(100);
+  short.id = 'short';
+
+  const long = new NBT.Tags.TAGLong();
+  long.setValue(1000);
+  long.id = 'long';
+
+  const float = new NBT.Tags.TAGFloat();
+  float.setValue(1.0);
+  float.id = 'float';
+
+  const double = new NBT.Tags.TAGDouble();
+  double.setValue(1.0);
+  double.id = 'double';
+
+  const byte = new NBT.Tags.TAGByte();
+  byte.setValue(1);
+  byte.id = 'byte';
+
+  const string = new NBT.Tags.TAGString();
+  let str = 'str';
+  for (let i = 0; i < byteCount; i++) {
+    str += 's';
+  }
+  string.setValue(str);
+  string.id = 'string';
+
+  const intArray = new NBT.Tags.TAGIntArray();
+  intArray.setValue(new Array(byteCount).fill(0));
+  intArray.id = 'intArray';
+
+  const int = new NBT.Tags.TAGInt();
+  int.setValue(1);
+  int.id = 'int';
+
+  const list = new NBT.Tags.TAGList();
+  list.id = 'list';
+
+  const l = [ short, short ];
+  list.setValue(l);
+
+  const resultNBT = new NBT.Tags.TAGCompound();
+  resultNBT.id = 'result';
+  resultNBT.setValue({
+    short,
+    long,
+    float,
+    double,
+    byte,
+    string,
+    intArray,
+    int,
+    list,
+  });
+
+  const nbt = new NBT();
+  nbt.root.result = resultNBT;
+
+  return nbt.writeToBuffer().length;
+}
+console.log('1b:byteLength:', test(), 'b');
+console.log('1kb:byteLength:', test(1024), 'b');
+console.log('2kb:byteLength:', test(2048), 'b');
+console.log('4kb:byteLength:', test(4096), 'b');
+console.log('8kb:byteLength:', test(8192), 'b');
+
+const suite = new Benchmark.Suite('', {});
+
+suite
+  .add('1b', () => {
+    test(1);
+  })
+  .add('1kb', () => {
+    test(1024);
+  })
+  .add('2kb', () => {
+    test(2048);
+  })
+  .add('4kb', () => {
+    test(4096);
+  })
+  .add('8kb', () => {
+    test(8192);
+  });
+
+suite
+  .on('cycle', event => {
+    console.log('v:', version, ', r:', String(event.target));
+  })
+  .on('complete', () => {
+    //
+  })
+  .run();

--- a/lib/bvffer.js
+++ b/lib/bvffer.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const defaultPoolSize = 64 * 1024;
+if (Buffer.poolSize < defaultPoolSize) {
+  Buffer.poolSize = defaultPoolSize;
+}
+
+class Bvffer {
+  constructor(buffByteLength) {
+    /**
+     * Buffer store data
+     */
+    this.buffer = Buffer.allocUnsafe(buffByteLength);
+    /**
+     * data length in buffer
+     */
+    this.dataByteLength = 0;
+  }
+
+  get dataLength() {
+    return this.dataByteLength;
+  }
+
+  get buff() {
+    return this.buffer;
+  }
+
+  /**
+   * write buffer data to buffer
+   * @param {Buffer} value data to write
+   */
+  writeBuffer(value) {
+    this.writeUInt16BE(value.length);
+
+    value.copy(this.buffer, this.dataByteLength);
+    this.dataByteLength += value.length;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeUInt8(value) {
+    this.buff[this.dataByteLength] = value;
+    this.dataByteLength += 1;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeInt8(value) {
+    this.buff[this.dataByteLength] = value;
+    this.dataByteLength += 1;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeUInt16BE(value) {
+    this.buffer.writeUInt16BE(value, this.dataByteLength);
+    this.dataByteLength += 2;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeInt16BE(value) {
+    this.buffer.writeInt16BE(value, this.dataByteLength);
+    this.dataByteLength += 2;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeUInt32BE(value) {
+    this.buffer.writeUInt32BE(value, this.dataByteLength);
+    this.dataByteLength += 4;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeInt32BE(value) {
+    this.buffer.writeInt32BE(value, this.dataByteLength);
+    this.dataByteLength += 4;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeDoubleBE(value) {
+    this.buffer.writeDoubleBE(value, this.dataByteLength);
+    this.dataByteLength += 8;
+  }
+
+  /**
+   * @param {number} value value
+   */
+  writeFloatBE(value) {
+    this.buffer.writeFloatBE(value, this.dataByteLength);
+    this.dataByteLength += 4;
+  }
+}
+
+exports.Bvffer = Bvffer;

--- a/lib/tags/byte.js
+++ b/lib/tags/byte.js
@@ -29,11 +29,9 @@ class TAGByte extends BaseTag {
    * Write body to buffer
    * @param {Buffer} buff The buffer to write to
    * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    buff.writeInt8(this.value, offset);
-    return 1;
+  writeBuffer(buff) {
+    buff.writeInt8(this.value);
   }
 
   /**

--- a/lib/tags/byte_array.js
+++ b/lib/tags/byte_array.js
@@ -12,6 +12,7 @@ class TAGByteArray extends BaseTag {
   constructor() {
     super();
     this.type = 'TAG_Byte_Array';
+    this.value = [];
   }
 
   /**
@@ -43,18 +44,15 @@ class TAGByteArray extends BaseTag {
 
   /**
    * Write body to buffer
-   * @param {Buffer} buff The buffer to write to
+   * @param {Bvffer} buff The buffer to write to
    * @param {number} offset The offset to start writing from
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    buff.writeUInt32BE(this.value.length, offset);
+  writeBuffer(buff) {
+    buff.writeUInt32BE(this.value.length);
 
     for (let i = 0; i < this.value.length; i++) {
-      buff.writeInt8(this.value[i], offset + 4 + i);
+      buff.writeInt8(this.value[i]);
     }
-
-    return 4 + this.value.length;
   }
 
   /**

--- a/lib/tags/compound.js
+++ b/lib/tags/compound.js
@@ -85,8 +85,7 @@ class TAGCompound extends BaseTag {
 
       // child type id for 1 byte, child name length for 2 bytes and child
       // name for (child name length) byte(s).
-      len += 1;
-      len += 2;
+      len += 3;
       len += Buffer.byteLength(this.value[key].id, 'utf8');
 
       // add the child body's length
@@ -101,29 +100,23 @@ class TAGCompound extends BaseTag {
 
   /**
    * Write body to buffer
-   * @param {Buffer} buff The buffer to write to
+   * @param {Bvffer} buff The buffer to write to
    * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    let len = 0;
+  writeBuffer(buff) {
     for (const key in this.value) {
       if (!this.value.hasOwnProperty(key)) continue;
 
       const object = this.value[key];
-      buff.writeUInt8(object.getTypeId(), offset + len);
+      buff.writeUInt8(object.getTypeId());
 
-      const nameBuff = new Buffer(object.id, 'utf8');
-      nameBuff.copy(buff, offset + len + 1 + 2);
-      buff.writeUInt16BE(nameBuff.length, offset + len + 1);
+      const nameBuff = Buffer.from(object.id, 'utf8');
+      buff.writeBuffer(nameBuff);
 
-      len += object.writeBuffer(buff, offset + len + 1 + 2 + nameBuff.length);
-      len += (1 + 2 + nameBuff.length);
+      object.writeBuffer(buff);
     }
 
-    buff.writeUInt8(0, offset + len);
-    len += 1;
-    return len;
+    buff.writeUInt8(0);
   }
 
   /**

--- a/lib/tags/double.js
+++ b/lib/tags/double.js
@@ -28,12 +28,9 @@ class TAGDouble extends BaseTag {
   /**
    * Write body to buffer
    * @param {Buffer} buff The buffer to write to
-   * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    buff.writeDoubleBE(this.value, offset);
-    return 8;
+  writeBuffer(buff) {
+    buff.writeDoubleBE(this.value);
   }
 
   /**

--- a/lib/tags/float.js
+++ b/lib/tags/float.js
@@ -28,12 +28,9 @@ class TAGFloat extends BaseTag {
   /**
    * Write body to buffer
    * @param {Buffer} buff The buffer to write to
-   * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    buff.writeFloatBE(this.value, offset);
-    return 4;
+  writeBuffer(buff) {
+    buff.writeFloatBE(this.value);
   }
 
   /**

--- a/lib/tags/int.js
+++ b/lib/tags/int.js
@@ -27,13 +27,10 @@ class TAGInt extends BaseTag {
 
   /**
    * Write body to buffer
-   * @param {Buffer} buff The buffer to write to
-   * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
+   * @param {Bvffer} buff The buffer to write to
    */
-  writeBuffer(buff, offset) {
-    buff.writeInt32BE(this.value, offset);
-    return 4;
+  writeBuffer(buff) {
+    buff.writeInt32BE(this.value);
   }
 
   /**

--- a/lib/tags/int_array.js
+++ b/lib/tags/int_array.js
@@ -136,17 +136,13 @@ class TAGIntArray extends BaseTag {
   /**
    * Write body to buffer
    * @param {Buffer} buff The buffer to write to
-   * @param {number} offset The offset to start writing from
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    buff.writeUInt32BE(this.value.length, offset);
+  writeBuffer(buff) {
+    buff.writeUInt32BE(this.value.length);
 
     for (let i = 0; i < this.value.length; i++) {
-      buff.writeInt32BE(this.value[i], offset + 4 + i * 4);
+      buff.writeInt32BE(this.value[i]);
     }
-
-    return 4 + this.value.length * 4;
   }
 }
 

--- a/lib/tags/list.js
+++ b/lib/tags/list.js
@@ -24,6 +24,7 @@ class TAGList extends BaseTag {
     this.type = 'TAG_List';
     this.childType = 'TAG_End';
     this.$tags = getTags();
+    this.value = [];
   }
 
   /**
@@ -53,10 +54,9 @@ class TAGList extends BaseTag {
     this.value = [];
     let nextOffset = offset + 1 + 4;
     for (let i = 0; i < len; i++) {
-      const element = (typeId === 0) ? undefined : new Tag();
-      const elementLength = (typeId === 0) ?
-        0 :
-        element._readBodyFromBuffer(buff, nextOffset);
+      const element = typeId === 0 ? undefined : new Tag();
+      const elementLength =
+        typeId === 0 ? 0 : element._readBodyFromBuffer(buff, nextOffset);
       nextOffset += elementLength;
 
       this.value.push(element);
@@ -72,7 +72,8 @@ class TAGList extends BaseTag {
   calcBufferLength() {
     return this.value.reduce(
       (sum, child) => sum + child.calcBufferLength(),
-      1 + 4);
+      1 + 4
+    );
   }
 
   /**
@@ -104,7 +105,8 @@ class TAGList extends BaseTag {
     for (let i = 0; i < value.length; i++) {
       if (!(value[i] instanceof TagType)) {
         throw new TypeError(
-          `Inconsistent TAG_List element type at position ${i}.`);
+          `Inconsistent TAG_List element type at position ${i}.`
+        );
       }
 
       array.push(value[i]);
@@ -220,26 +222,21 @@ class TAGList extends BaseTag {
   /**
    * Write body to buffer
    * @param {Buffer} buff The buffer to write to
-   * @param {number} offset The offset to start writing from
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
+  writeBuffer(buff) {
     // no element
     if (!this.value.length) {
-      buff.writeUInt8(0, offset);
-      buff.writeUInt32BE(0, offset + 1);
-      return 1 + 4;
+      buff.writeUInt8(0);
+      buff.writeUInt32BE(0);
+      return;
     }
 
-    buff.writeUInt8(this.value[0].getTypeId(), offset);
-    buff.writeUInt32BE(this.value.length, offset + 1);
-    let len = 0;
-    const baseOffset = offset + 1 + 4;
+    buff.writeUInt8(this.value[0].getTypeId());
+    buff.writeUInt32BE(this.value.length);
+
     for (let i = 0; i < this.value.length; i++) {
-      len += this.value[i].writeBuffer(buff, baseOffset + len);
+      this.value[i].writeBuffer(buff);
     }
-
-    return len + 1 + 4;
   }
 }
 

--- a/lib/tags/long.js
+++ b/lib/tags/long.js
@@ -20,12 +20,11 @@ class TAGLong extends BaseTag {
     return 8;
   }
 
-  writeBuffer(buff, offset) {
+  writeBuffer(buff) {
     const bytes = this.value.toBytesBE();
-    for (let i = 0, j = offset; i < 8; i++, j++) {
-      buff.writeUInt8(bytes[i], j);
+    for (let i = 0; i < 8; i++) {
+      buff.writeUInt8(bytes[i]);
     }
-    return 8;
   }
 
   toJSON() {

--- a/lib/tags/short.js
+++ b/lib/tags/short.js
@@ -27,13 +27,10 @@ class TAGShort extends BaseTag {
 
   /**
    * Write body to buffer
-   * @param {Buffer} buff The buffer to write to
-   * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
+   * @param {Bvffer} buff The buffer to write to
    */
-  writeBuffer(buff, offset) {
-    buff.writeInt16BE(this.value, offset);
-    return 2;
+  writeBuffer(buff) {
+    buff.writeInt16BE(this.value);
   }
 
   /**

--- a/lib/tags/string.js
+++ b/lib/tags/string.js
@@ -39,15 +39,11 @@ class TAGString extends BaseTag {
    * Write body to buffer
    * @param {Buffer} buff The buffer to write to
    * @param {number} offset The offset to start writing to
-   * @return {number} The number of bytes written
    */
-  writeBuffer(buff, offset) {
-    const strBuff = new Buffer(this.value, 'utf8');
+  writeBuffer(buff) {
+    const strBuff = Buffer.from(this.value, 'utf8');
 
-    strBuff.copy(buff, offset + 2);
-    buff.writeUInt16BE(strBuff.length, offset);
-
-    return 2 + strBuff.length;
+    buff.writeBuffer(strBuff);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcnbt",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Yet another Minecraft NBT format file / buffer parser for Node.js.",
   "main": "nbt.js",
   "scripts": {

--- a/types/lib/bvffer.d.ts
+++ b/types/lib/bvffer.d.ts
@@ -1,0 +1,30 @@
+/**
+ * The Bvffer class
+ */
+declare class Bvffer {
+  constructor(buffByteLength: number);
+
+  get dataLength(): number;
+
+  get buff(): Buffer;
+
+  writeBuffer(value): void;
+
+  writeUInt8(value): void;
+
+  writeInt8(value): void;
+
+  writeUInt16BE(value): void;
+
+  writeInt16BE(value): void;
+
+  writeUInt32BE(value): void;
+
+  writeInt32BE(value): void;
+
+  writeFloatBE(value): void;
+
+  writeDoubleBE(value): void;
+}
+
+export = Bvffer;


### PR DESCRIPTION
v: 2.0.1 , r: 1b x 66,319 ops/sec ±70.40% (88 runs sampled)
v: 2.0.1 , r: 1kb x 32,589 ops/sec ±0.96% (90 runs sampled)
v: 2.0.1 , r: 2kb x 18,932 ops/sec ±0.51% (93 runs sampled)
v: 2.0.1 , r: 4kb x 10,554 ops/sec ±0.44% (94 runs sampled)
v: 2.0.1 , r: 8kb x 5,425 ops/sec ±0.56% (91 runs sampled)

v: 2.0.2 , r: 1b x 159,682 ops/sec ±0.49% (92 runs sampled)
v: 2.0.2 , r: 1kb x 35,753 ops/sec ±0.57% (90 runs sampled)
v: 2.0.2 , r: 2kb x 19,579 ops/sec ±0.67% (95 runs sampled)
v: 2.0.2 , r: 4kb x 10,397 ops/sec ±0.48% (95 runs sampled)
v: 2.0.2 , r: 8kb x 5,168 ops/sec ±0.35% (95 runs sampled)